### PR TITLE
Add a .pc file to NTL

### DIFF
--- a/src/DoConfig
+++ b/src/DoConfig
@@ -413,6 +413,7 @@ sub GenFiles {
    while ($line = <NTLPCIN>) {
 
       $line =~ s/@\{(.*?)\}/$MakeSub{$1}/ge;
+      $line =~ tr/()/{}/;
 
       print NTLPC $line;
 

--- a/src/DoConfig
+++ b/src/DoConfig
@@ -397,7 +397,22 @@ sub GenFiles {
    close(MFILE);
    close(MFILEOUT);
    
-   
+   # generate ntl.pc
+
+   open(NTLPCIN, "< ntl.pc.in");
+   open(NTLPC, "> ntl.pc");
+
+   while ($line = <NTLPCIN>) {
+
+      $line =~ s/@\{(.*?)\}/$MakeSub{$1}/ge;
+
+      print NTLPC $line;
+
+   }
+
+   close(NTLPCIN);
+   close(NTLPC);
+
    # generate config.h
    
    

--- a/src/DoConfig
+++ b/src/DoConfig
@@ -47,6 +47,8 @@ system("echo '*** CompilerOutput.log ***' > CompilerOutput.log");
 
 'TUNE'         => 'generic',
 
+'PACKAGE_VERSION'  => undef,
+
 );
 
 
@@ -283,6 +285,12 @@ if ($ConfigFlag{'NTL_GF2X_LIB'} eq 'on') {
    }
 }
 
+# retrieve ntl version from DIRNAME
+open(DIRNAME, "< DIRNAME");
+@versionline = split('-',<DIRNAME>);
+chomp($versionline[1]);
+$MakeVal{'PACKAGE_VERSION'} = $versionline[1];
+close(DIRNAME);
 
 # copy %MakeVal and %MakeFlag as is into %MakeSub
 

--- a/src/mfile
+++ b/src/mfile
@@ -453,7 +453,9 @@ install:
 @{LSTAT}	cp -p ntl.a $(DESTDIR)$(LIBDIR)/libntl.a #LSTAT
 @{LSTAT}	- chmod a+r $(DESTDIR)$(LIBDIR)/libntl.a #LSTAT
 @{LSHAR}	$(LIBTOOL) --mode=install cp -p libntl.la $(DESTDIR)$(LIBDIR) #LSHAR
-
+	mkdir -p -m 755 $(DESTDIR)$(LIBDIR)/pkgconfig
+	cp -p ntl.pc $(DESTDIR)$(LIBDIR)/pkgconfig/
+	- chmod a+r $(DESTDIR)$(LIBDIR)/pkgconfig/ntl.pc
 
 uninstall:
 @{LSTAT}	rm -f $(LIBDIR)/libntl.a #LSTAT

--- a/src/ntl.pc.in
+++ b/src/ntl.pc.in
@@ -1,0 +1,19 @@
+# Define these NTL configuration variables as they may not be 
+# substited by DoConfig
+DEF_PREFIX=@{DEF_PREFIX}
+PREFIX=@{PREFIX}
+# optional dependencies
+@{GF2X}GF2X_PKG=gf2x
+@{GMP}GMP_PKG=gmp
+# Normal pc file starts here
+prefix=@{PREFIX}
+libdir=@{LIBDIR}
+includedir=@{INCLUDEDIR}/NTL
+
+Name: ntl
+URL: http://www.shoup.net/
+Description: A library for doing number theory
+#Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lntl
+Cflags: -I${includedir} @{CXXAUTOFLAGS}
+Requires.private: ${GF2X_PKG} ${GMP_PKG}

--- a/src/ntl.pc.in
+++ b/src/ntl.pc.in
@@ -8,7 +8,7 @@ PREFIX=@{PREFIX}
 # Normal pc file starts here
 prefix=@{PREFIX}
 libdir=@{LIBDIR}
-includedir=@{INCLUDEDIR}/NTL
+includedir=@{INCLUDEDIR}
 
 Name: ntl
 URL: http://www.shoup.net/

--- a/src/ntl.pc.in
+++ b/src/ntl.pc.in
@@ -13,7 +13,7 @@ includedir=@{INCLUDEDIR}/NTL
 Name: ntl
 URL: http://www.shoup.net/
 Description: A library for doing number theory
-#Version: @PACKAGE_VERSION@
+Version: @{PACKAGE_VERSION}
 Libs: -L${libdir} -lntl
 Cflags: -I${includedir} @{CXXAUTOFLAGS}
 Requires.private: ${GF2X_PKG} ${GMP_PKG}


### PR DESCRIPTION
Adding a .pc file for NTL helps downstream applications and library to properly find the library and headers in a standard way. 