### PR TITLE
build: set PKGDIR in relation to LIBDIR

### DIFF
--- a/src/DoConfig
+++ b/src/DoConfig
@@ -59,7 +59,7 @@ system("echo '*** CompilerOutput.log ***' > CompilerOutput.log");
 'LIBDIR'      => '$(PREFIX)/lib',
 'INCLUDEDIR'  => '$(PREFIX)/include',
 'DOCDIR'      => '$(PREFIX)/share/doc',
-'PKGDIR'      => '$(PREFIX)/lib/pkgconfig',
+'PKGDIR'      => '$(LIBDIR)/pkgconfig',
 
 'GMP_PREFIX'  => '$(DEF_PREFIX)',
 'GMP_INCDIR'  => '$(GMP_PREFIX)/include',


### PR DESCRIPTION
If LIBDIR is overridden, it should carry forward to PKGDIR, as would be the case when running an equivalent autoconf/automake-based configure script.